### PR TITLE
Loosen singleton pattern

### DIFF
--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -1,10 +1,7 @@
 require 'openid_connect'
-require 'singleton'
 
 module OpenIDTokenProxy
   class Config
-    include Singleton
-
     attr_accessor :client_id, :client_secret, :issuer, :resource
     attr_accessor :authorization_endpoint, :token_endpoint, :userinfo_endpoint
 
@@ -40,6 +37,10 @@ module OpenIDTokenProxy
     def public_keys
       # TODO: Allow configuration of public keys manually
       provider_config.public_keys
+    end
+
+    def self.instance
+      @instance ||= new
     end
   end
 end

--- a/spec/lib/openid_token_proxy/config_spec.rb
+++ b/spec/lib/openid_token_proxy/config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe OpenIDTokenProxy::Config do
-  subject { described_class.send(:new) }
+  subject { described_class.new }
   let(:with_valid_issuer) {
     subject.issuer = 'https://login.windows.net/common'
     subject
@@ -143,6 +143,14 @@ RSpec.describe OpenIDTokenProxy::Config do
     it 'retrieves public keys from provider' do
       keys = with_valid_issuer.public_keys
       expect(keys.first).to be_an OpenSSL::PKey::PKey
+    end
+  end
+
+  describe '::instance' do
+    it 'returns global configuration' do
+      instance = described_class.instance
+      expect(instance).to eq described_class.instance
+      expect(instance).to be_a described_class
     end
   end
 end


### PR DESCRIPTION
This simplifies testing and also allows instantiating a custom configuration without relying on the global one.
