### PR TITLE
Normalize singletons

### DIFF
--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -8,6 +8,14 @@ require 'openid_token_proxy/version'
 
 module OpenIDTokenProxy
   class << self
+    def client
+      @client ||= Client.new
+    end
+
+    def config
+      @config ||= Config.new
+    end
+
     def configure
       yield config
     end
@@ -19,10 +27,6 @@ module OpenIDTokenProxy
       yield @config
     ensure
       @config = original
-    end
-
-    def config
-      @config ||= Config.new
     end
   end
 end

--- a/lib/openid_token_proxy/client.rb
+++ b/lib/openid_token_proxy/client.rb
@@ -38,9 +38,5 @@ module OpenIDTokenProxy
         redirect_uri:           config.redirect_uri
       )
     end
-
-    def self.instance
-      @instance ||= new
-    end
   end
 end

--- a/spec/lib/openid_token_proxy/client_spec.rb
+++ b/spec/lib/openid_token_proxy/client_spec.rb
@@ -99,12 +99,4 @@ RSpec.describe OpenIDTokenProxy::Client do
       end
     end
   end
-
-  describe '::instance' do
-    it 'returns global client' do
-      instance = described_class.instance
-      expect(instance).to eq described_class.instance
-      expect(instance).to be_a described_class
-    end
-  end
 end

--- a/spec/lib/openid_token_proxy_spec.rb
+++ b/spec/lib/openid_token_proxy_spec.rb
@@ -1,6 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe OpenIDTokenProxy do
+  describe '::client' do
+    it 'returns global client' do
+      client = described_class.client
+      expect(client).to eq described_class.client
+      expect(client).to be_a OpenIDTokenProxy::Client
+    end
+  end
+
+  describe '::config' do
+    it 'returns global configuration' do
+      config = described_class.config
+      expect(config).to eq described_class.config
+      expect(config).to be_a OpenIDTokenProxy::Config
+    end
+  end
+
   describe '::configure' do
     it 'yields configuration' do
       expect do |probe|


### PR DESCRIPTION
This normalizes the configuration and client singletons into `OpenIDTokenProxy.client` and `OpenIDTokenProxy.config`.

Reads much nicer than `OpenIDTokenProxy::Client.instance`.