### PR TITLE
Add informational homepage

### DIFF
--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -1,0 +1,1 @@
+Visit <a href="<%= OpenIDTokenProxy.client.authorization_uri %>"> authorization URI</a> and sign in.

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
     dt {
       font-weight: bold;
-      margin-top: 1em;
+      margin: 1em 0 .2em;
     }
 
     dd {

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -2,13 +2,52 @@
 <html>
 <head>
   <title>OpenID token proxy</title>
+  <meta charset="utf8" />
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <style>
+    body {
+      font: 14px 'Helvetica';
+      line-height: 1.2em;
+    }
+
+    dt {
+      font-weight: bold;
+      margin-top: 1em;
+    }
+
+    dd {
+      margin: 0 1em;
+    }
+
+    hr {
+      margin: 2em 0;
+      border: 1px solid #DDDDDD;
+    }
+  </style>
 </head>
 <body>
+  <%
+    client = OpenIDTokenProxy.client
+    config = OpenIDTokenProxy.config
+  %>
 
-<%= yield %>
+  <dl>
+    <dt>Client ID</dt>
+    <dd><%= config.client_id %></dd>
+    <dt>Client secret</dt>
+    <dd><%= config.client_secret %></dd>
+    <dt>Issuer</dt>
+    <dd><%= config.issuer %></dd>
+    <dt>Public keys</dt>
+    <dd><%= config.public_keys.count %></dd>
+    <dt>Authorization URI</dt>
+    <dd><%= client.authorization_uri %></dd>
+  </dl>
 
+  <hr />
+
+  <%= yield %>
 </body>
 </html>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  root to: 'home#index'
   mount OpenIDTokenProxy::Engine, at: '/auth'
 end


### PR DESCRIPTION
This dummy homepage is accessible by running the Rails server in the `spec/dummy` folder.

At present it shows the configuration, to be extended to exemplify the entire flow.

![screen shot 2015-04-13 at 13 09 48](https://cloud.githubusercontent.com/assets/378235/7114548/9e7ace58-e1de-11e4-897c-4bb2493235d0.png)
