### PR TITLE
Callback controller

### DIFF
--- a/app/controllers/openid_token_proxy/application_controller.rb
+++ b/app/controllers/openid_token_proxy/application_controller.rb
@@ -1,0 +1,4 @@
+module OpenIDTokenProxy
+  class ApplicationController < ActionController::Base
+  end
+end

--- a/app/controllers/openid_token_proxy/callback_controller.rb
+++ b/app/controllers/openid_token_proxy/callback_controller.rb
@@ -1,0 +1,20 @@
+module OpenIDTokenProxy
+  class CallbackController < ApplicationController
+    def handle
+      unless code = params[:code]
+        render nothing: true, status: :bad_request
+        return
+      end
+
+      begin
+        token = OpenIDTokenProxy.client.token_via_auth_code!(code)
+      rescue OpenIDTokenProxy::Client::AuthCodeException => error
+        # Rescued here and passed into the token acquirement hook below
+      end
+
+      config = OpenIDTokenProxy.config
+      uri = instance_exec token, error, &config.token_acquirement_hook
+      redirect_to uri || main_app.root_url unless performed?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
 OpenIDTokenProxy::Engine.routes.draw do
+  get :callback, to: 'callback#handle'
 end

--- a/lib/openid_token_proxy/client.rb
+++ b/lib/openid_token_proxy/client.rb
@@ -23,7 +23,8 @@ module OpenIDTokenProxy
     def token_via_auth_code!(auth_code)
       client = new_client
       client.authorization_code = auth_code
-      Token.new(client.access_token!(:query_string))
+      response = client.access_token!(:query_string)
+      Token.new(response.access_token, response.refresh_token)
     rescue Rack::OAuth2::Client::Error => e
       raise AuthCodeException.new(e.message)
     end

--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -6,6 +6,7 @@ module OpenIDTokenProxy
     attr_accessor :domain_hint, :prompt, :redirect_uri, :resource
     attr_accessor :authorization_uri
     attr_accessor :authorization_endpoint, :token_endpoint, :userinfo_endpoint
+    attr_accessor :token_acquirement_hook
 
     def initialize
       @client_id = ENV['OPENID_CLIENT_ID']
@@ -22,6 +23,8 @@ module OpenIDTokenProxy
       @authorization_endpoint = ENV['OPENID_AUTHORIZATION_ENDPOINT']
       @token_endpoint = ENV['OPENID_TOKEN_ENDPOINT']
       @userinfo_endpoint = ENV['OPENID_USERINFO_ENDPOINT']
+
+      @token_acquirement_hook = proc { }
 
       yield self if block_given?
     end

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -1,9 +1,10 @@
 module OpenIDTokenProxy
   class Token
-    attr_reader :access_token
+    attr_accessor :access_token, :refresh_token
 
-    def initialize(access_token)
+    def initialize(access_token, refresh_token = nil)
       @access_token = access_token
+      @refresh_token = refresh_token
     end
   end
 end

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -6,5 +6,9 @@ module OpenIDTokenProxy
       @access_token = access_token
       @refresh_token = refresh_token
     end
+
+    def to_s
+      @access_token
+    end
   end
 end

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
+  routes { OpenIDTokenProxy::Engine.routes }
+  let(:access_token) { 'access token' }
+  let(:auth_code) { 'authorization code' }
+  let(:client) { OpenIDTokenProxy.client }
+  let(:token) { double(access_token: access_token) }
+
+  context 'when authorization code is missing' do
+    it 'returns 400 BAD REQUEST' do
+      get :handle
+      expect(response.body).to be_blank
+      expect(response.status).to eq 400
+    end
+  end
+
+  context 'when authorization code is given' do
+    before do
+      expect(client).to receive(:token_via_auth_code!).and_return token
+    end
+
+    context 'with no-op token acquirement hook' do
+      it 'redirects to root' do
+        OpenIDTokenProxy.configure_temporarily do |config|
+          config.token_acquirement_hook = proc { }
+          get :handle, code: auth_code
+          expect(response).to redirect_to controller.main_app.root_url
+        end
+      end
+    end
+
+    context 'when returning URI from token acquirement hook' do
+      it 'redirects to returned URI' do
+        OpenIDTokenProxy.configure_temporarily do |config|
+          uri = '/#token'
+          config.token_acquirement_hook = proc { |token, error|
+            uri
+          }
+          get :handle, code: auth_code
+          expect(response).to redirect_to uri
+        end
+      end
+    end
+
+    context 'when performing an action within token acquirement hook' do
+      it 'takes no additional action' do
+        OpenIDTokenProxy.configure_temporarily do |config|
+          config.token_acquirement_hook = proc { |token, error|
+            render text: 'Custom action'
+          }
+          get :handle, code: auth_code
+          expect(response.body).to eq 'Custom action'
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/config/initializers/openid.rb
+++ b/spec/dummy/config/initializers/openid.rb
@@ -1,0 +1,5 @@
+OpenIDTokenProxy.configure do |config|
+  config.token_acquirement_hook = proc { |token, error|
+    main_app.root_url + "?token=#{token}"
+  }
+end

--- a/spec/lib/openid_token_proxy/client_spec.rb
+++ b/spec/lib/openid_token_proxy/client_spec.rb
@@ -92,10 +92,11 @@ RSpec.describe OpenIDTokenProxy::Client do
 
     context 'when auth code is valid' do
       it 'returns token instance' do
-        access_token = double
+        access_token = double(access_token: 'access token', refresh_token: 'refresh token')
         expect(client).to receive(:access_token!).and_return access_token
         token = subject.token_via_auth_code! 'valid auth code'
-        expect(token.access_token).to eq access_token
+        expect(token.access_token).to eq 'access token'
+        expect(token.refresh_token).to eq 'refresh token'
       end
     end
   end


### PR DESCRIPTION
Used to retrieve initial access and refresh tokens. The `token_acquirement_hook` is to be configured in the host application.

Documentation will follow in a later PR.