### PR TITLE
Allow configuring public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ OpenIDTokenProxy.configure do |config|
   # Whether to force authentication in case a session is already established
   config.prompt = 'login'
 
-  # These endpoints may be omitted and will automatically be discovered by
-  # contacting the given issuer
+  # If these endpoints or public keys are not configured explicitly, they will be
+  # discovered automatically by contacting the issuer (see above)
   config.authorization_endpoint = 'https://login.windows.net/common/oauth2/authorize'
   config.token_endpoint = 'https://login.windows.net/common/oauth2/token'
   config.userinfo_endpoint = 'https://login.windows.net/common/openid/userinfo'
+  config.public_keys = [
+    OpenSSL::PKey::RSA.new("-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9...")
+  ]
 
   # Alternatively, you can override the authorization URI in its entirety:
   config.authorization_uri = 'https://id.hyper.no/authorize?prompt=login'

--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -7,6 +7,7 @@ module OpenIDTokenProxy
     attr_accessor :authorization_uri
     attr_accessor :authorization_endpoint, :token_endpoint, :userinfo_endpoint
     attr_accessor :token_acquirement_hook
+    attr_accessor :public_keys
 
     def initialize
       @client_id = ENV['OPENID_CLIENT_ID']
@@ -49,8 +50,7 @@ module OpenIDTokenProxy
     end
 
     def public_keys
-      # TODO: Allow configuration of public keys manually
-      provider_config.public_keys
+      @public_keys ||= provider_config.public_keys
     end
   end
 end

--- a/spec/lib/openid_token_proxy/config_spec.rb
+++ b/spec/lib/openid_token_proxy/config_spec.rb
@@ -177,9 +177,16 @@ RSpec.describe OpenIDTokenProxy::Config do
   end
 
   describe '#public_keys' do
-    it 'retrieves public keys from provider' do
-      keys = with_valid_issuer.public_keys
-      expect(keys.first).to be_an OpenSSL::PKey::PKey
+    it 'may be set explicitly' do
+      subject.public_keys = []
+      expect(subject.public_keys).to eq []
+    end
+
+    context 'when not set' do
+      it 'retrieves public keys from provider' do
+        keys = with_valid_issuer.public_keys
+        expect(keys.first).to be_an OpenSSL::PKey::PKey
+      end
     end
   end
 end


### PR DESCRIPTION
For identity providers that do not conform to [OpenID's discovery standard](https://openid.net/specs/openid-connect-discovery-1_0.html), one may want to configure public keys manually.