### PR TITLE
Token validation

### DIFF
--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -20,6 +20,30 @@ module OpenIDTokenProxy
       @access_token
     end
 
+    # Validates this token's expiration state, application, audience and issuer
+    def validate!(assertions = {})
+      raise Expired if expired?
+
+      # TODO: Nonce validation
+
+      if assertions[:audience]
+        audiences = Array(id_token.aud)
+        raise InvalidAudience unless audiences.include? assertions[:audience]
+      end
+
+      if assertions[:client_id]
+        appid = id_token.raw_attributes['appid']
+        raise InvalidApplication if appid && appid != assertions[:client_id]
+      end
+
+      if assertions[:issuer]
+        issuer = id_token.iss
+        raise InvalidIssuer unless issuer == assertions[:issuer]
+      end
+
+      true
+    end
+
     def expired?
       id_token.exp.to_i <= Time.now.to_i
     end

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -20,6 +20,10 @@ module OpenIDTokenProxy
       @access_token
     end
 
+    def expired?
+      id_token.exp.to_i <= Time.now.to_i
+    end
+
     # Decodes given access token and validates its signature by public key(s)
     # Use :skip_verification as second argument to skip signature validation
     def self.decode!(access_token, keys = OpenIDTokenProxy.config.public_keys)

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -1,3 +1,7 @@
+require 'openid_token_proxy/token/expired'
+require 'openid_token_proxy/token/invalid_application'
+require 'openid_token_proxy/token/invalid_audience'
+require 'openid_token_proxy/token/invalid_issuer'
 require 'openid_token_proxy/token/malformed'
 require 'openid_token_proxy/token/required'
 require 'openid_token_proxy/token/unverifiable_signature'

--- a/lib/openid_token_proxy/token/expired.rb
+++ b/lib/openid_token_proxy/token/expired.rb
@@ -1,0 +1,12 @@
+module OpenIDTokenProxy
+  class Token
+
+    # Raised when a token has expired
+    class Expired < Error
+      def initialize
+        super 'Token has expired.'
+      end
+    end
+
+  end
+end

--- a/lib/openid_token_proxy/token/invalid_application.rb
+++ b/lib/openid_token_proxy/token/invalid_application.rb
@@ -1,0 +1,12 @@
+module OpenIDTokenProxy
+  class Token
+
+    # Raised when a token's application did not match
+    class InvalidApplication < Error
+      def initialize
+        super 'Token is not intended for this application.'
+      end
+    end
+
+  end
+end

--- a/lib/openid_token_proxy/token/invalid_audience.rb
+++ b/lib/openid_token_proxy/token/invalid_audience.rb
@@ -1,0 +1,12 @@
+module OpenIDTokenProxy
+  class Token
+
+    # Raised when a token's audience did not match
+    class InvalidAudience < Error
+      def initialize
+        super 'Token was issued for an unexpected audience/resource.'
+      end
+    end
+
+  end
+end

--- a/lib/openid_token_proxy/token/invalid_issuer.rb
+++ b/lib/openid_token_proxy/token/invalid_issuer.rb
@@ -1,0 +1,12 @@
+module OpenIDTokenProxy
+  class Token
+
+    # Raised when a token's issuer did not match
+    class InvalidIssuer < Error
+      def initialize
+        super 'Token was issued by an unexpected issuer.'
+      end
+    end
+
+  end
+end

--- a/spec/lib/openid_token_proxy/token_spec.rb
+++ b/spec/lib/openid_token_proxy/token_spec.rb
@@ -25,6 +25,53 @@ RSpec.describe OpenIDTokenProxy::Token do
     end
   end
 
+  describe '#validate!' do
+    context 'when token has expired' do
+      let(:expiry_date) { 2.hours.ago }
+
+      it 'raises' do
+        expect do
+          subject.validate!
+        end.to raise_error OpenIDTokenProxy::Token::Expired
+      end
+    end
+
+    context 'when application differs' do
+      it 'raises' do
+        expect do
+          subject.validate! client_id: 'invalid client ID'
+        end.to raise_error OpenIDTokenProxy::Token::InvalidApplication
+      end
+    end
+
+    context 'when audience differs' do
+      it 'raises' do
+        expect do
+          subject.validate! audience: 'invalid audience'
+        end.to raise_error OpenIDTokenProxy::Token::InvalidAudience
+      end
+    end
+
+    context 'when issuer differs' do
+      it 'raises' do
+        expect do
+          subject.validate! issuer: 'invalid issuer'
+        end.to raise_error OpenIDTokenProxy::Token::InvalidIssuer
+      end
+    end
+
+    context 'when all is well' do
+      it 'returns true' do
+        assertions = {
+          audience: audience,
+          client_id: client_id,
+          issuer: issuer
+        }
+        expect(subject.validate! assertions).to be_truthy
+      end
+    end
+  end
+
   describe '#expired?' do
     context 'when token has expired' do
       let(:expiry_date) { 2.hours.ago }

--- a/spec/lib/openid_token_proxy/token_spec.rb
+++ b/spec/lib/openid_token_proxy/token_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe OpenIDTokenProxy::Token do
     context 'when application differs' do
       it 'raises' do
         expect do
-          subject.validate! client_id: 'invalid client ID'
+          subject.validate! client_id: 'expected client ID'
         end.to raise_error OpenIDTokenProxy::Token::InvalidApplication
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe OpenIDTokenProxy::Token do
     context 'when audience differs' do
       it 'raises' do
         expect do
-          subject.validate! audience: 'invalid audience'
+          subject.validate! audience: 'expected audience'
         end.to raise_error OpenIDTokenProxy::Token::InvalidAudience
       end
     end
@@ -55,7 +55,7 @@ RSpec.describe OpenIDTokenProxy::Token do
     context 'when issuer differs' do
       it 'raises' do
         expect do
-          subject.validate! issuer: 'invalid issuer'
+          subject.validate! issuer: 'expected issuer'
         end.to raise_error OpenIDTokenProxy::Token::InvalidIssuer
       end
     end

--- a/spec/lib/openid_token_proxy/token_spec.rb
+++ b/spec/lib/openid_token_proxy/token_spec.rb
@@ -1,11 +1,38 @@
 require 'spec_helper'
 
 RSpec.describe OpenIDTokenProxy::Token do
-  subject { described_class.new 'access token' }
+  subject { described_class.new 'access token', id_token }
+
+  let(:audience) { 'audience' }
+  let(:client_id) { 'client ID' }
+  let(:issuer) { 'issuer' }
+  let(:expiry_date) { 2.hours.from_now }
+
+  let(:id_token) {
+    double(
+      exp: expiry_date,
+      aud: audience,
+      iss: issuer,
+      raw_attributes: {
+        'appid' => client_id
+      }
+    )
+  }
 
   describe '#to_s' do
     it 'returns access token' do
       expect(subject.to_s).to eq 'access token'
+    end
+  end
+
+  describe '#expired?' do
+    context 'when token has expired' do
+      let(:expiry_date) { 2.hours.ago }
+      it { should be_expired }
+    end
+
+    context 'when token has not yet expired' do
+      it { should_not be_expired }
     end
   end
 


### PR DESCRIPTION
Based on [nov's `IdToken#verify`](https://github.com/nov/openid_connect/blob/master/lib/openid_connect/response_object/id_token.rb#L21-L27), which we unfortunately cannot use out of the box because we'd like to discern between expired tokens and invalid application/audience/issuer.