### PR TITLE
Add authentication module

### DIFF
--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -4,6 +4,7 @@ require 'openid_connect'
 
 require 'openid_token_proxy/error'
 
+require 'openid_token_proxy/authentication'
 require 'openid_token_proxy/client'
 require 'openid_token_proxy/config'
 require 'openid_token_proxy/engine'

--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -29,9 +29,11 @@ module OpenIDTokenProxy
     def configure_temporarily
       original = config
       @config = original.dup
+      client.config = @config
       yield @config
     ensure
       @config = original
+      client.config = @config
     end
   end
 end

--- a/lib/openid_token_proxy/authentication.rb
+++ b/lib/openid_token_proxy/authentication.rb
@@ -1,0 +1,52 @@
+require 'active_support/concern'
+
+module OpenIDTokenProxy
+  module Authentication
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from OpenIDTokenProxy::Error, with: :require_authorization
+
+      helper_method :current_token, :raw_token
+    end
+
+    module ClassMethods
+      def require_valid_token(*args)
+        before_action :require_valid_token, *args
+      end
+    end
+
+    def set_authorization_uri!
+      uri = OpenIDTokenProxy.client.authorization_uri
+      response.headers['X-Authorization-URI'] = uri
+    end
+
+    def require_authorization(exception)
+      set_authorization_uri!
+      render json: exception.to_json, status: :unauthorized
+    end
+
+    def require_valid_token
+      config = OpenIDTokenProxy.config
+      current_token.validate! audience: config.resource,
+                              client_id: config.client_id
+    end
+
+    def current_token
+      @current_token ||= OpenIDTokenProxy::Token.decode!(raw_token)
+    end
+
+    def raw_token
+      token = params[:token]
+      return token if token
+
+      authorization = request.headers['Authorization']
+      if authorization
+        token = authorization[/Bearer (.+)/, 1]
+        return token if token
+      end
+
+      request.headers['X-Token']
+    end
+  end
+end

--- a/lib/openid_token_proxy/client.rb
+++ b/lib/openid_token_proxy/client.rb
@@ -1,6 +1,6 @@
 module OpenIDTokenProxy
   class Client
-    attr_reader :config
+    attr_accessor :config
 
     def initialize(config = OpenIDTokenProxy.config)
       @config = config

--- a/spec/lib/openid_token_proxy/authentication_spec.rb
+++ b/spec/lib/openid_token_proxy/authentication_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    include OpenIDTokenProxy::Authentication
+
+    require_valid_token
+
+    def index
+      raise OpenIDTokenProxy::Error if params[:error]
+      render nothing: true, status: :ok
+    end
+  end
+
+  context 'when token proxy errors are encountered' do
+    it 'results in 401 UNAUTHORIZED with authorization URI' do
+      get :index, error: true
+      expect(response).to have_http_status :unauthorized
+      expect(response.headers).to have_key 'X-Authorization-URI'
+    end
+  end
+
+  context 'when no token proxy errors are encountered' do
+    it 'executes actions normally' do
+      token = double(validate!: true)
+      expect(controller).to receive(:current_token).and_return token
+      get :index
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  describe '#current_token' do
+    it 'returns current valid token' do
+      token = double
+      expect(OpenIDTokenProxy::Token).to receive(:decode!).and_return token
+      expect(controller.current_token).to eq token
+    end
+  end
+
+  describe '#raw_token' do
+    it 'may be provided as parameter' do
+      get :index, token: 'raw token'
+      expect(controller.raw_token).to eq 'raw token'
+    end
+
+    it 'may be provided through authorization header' do
+      request.headers['Authorization'] = 'Bearer raw token'
+      get :index
+      expect(controller.raw_token).to eq 'raw token'
+    end
+
+    it 'may be provided through X-Token header' do
+      request.headers['X-Token'] = 'raw token'
+      get :index
+      expect(controller.raw_token).to eq 'raw token'
+    end
+  end
+end


### PR DESCRIPTION
This adds an authentication module to be included into API controllers and allows for tokens to be provided using one of:

- Query string parameter `token`
- `Authorization: Bearer <token>` header
- `X-Token` header