### PR TITLE
Identity information on homepage

### DIFF
--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -4,6 +4,7 @@ require 'openid_connect'
 
 require 'openid_token_proxy/error'
 
+require 'openid_token_proxy/authentication'
 require 'openid_token_proxy/client'
 require 'openid_token_proxy/config'
 require 'openid_token_proxy/engine'

--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -29,9 +29,11 @@ module OpenIDTokenProxy
     def configure_temporarily
       original = config
       @config = original.dup
+      client.config = @config
       yield @config
     ensure
       @config = original
+      client.config = @config
     end
   end
 end

--- a/lib/openid_token_proxy/authentication.rb
+++ b/lib/openid_token_proxy/authentication.rb
@@ -1,0 +1,52 @@
+require 'active_support/concern'
+
+module OpenIDTokenProxy
+  module Authentication
+    extend ActiveSupport::Concern
+
+    included do
+      rescue_from OpenIDTokenProxy::Error, with: :require_authorization
+
+      helper_method :current_token, :raw_token
+    end
+
+    module ClassMethods
+      def require_valid_token(*args)
+        before_action :require_valid_token, *args
+      end
+    end
+
+    def set_authorization_uri!
+      uri = OpenIDTokenProxy.client.authorization_uri
+      response.headers['X-Authorization-URI'] = uri
+    end
+
+    def require_authorization(exception)
+      set_authorization_uri!
+      render json: exception.to_json, status: :unauthorized
+    end
+
+    def require_valid_token
+      config = OpenIDTokenProxy.config
+      current_token.validate! audience: config.resource,
+                              client_id: config.client_id
+    end
+
+    def current_token
+      @current_token ||= OpenIDTokenProxy::Token.decode!(raw_token)
+    end
+
+    def raw_token
+      token = params[:token]
+      return token if token
+
+      authorization = request.headers['Authorization']
+      if authorization
+        token = authorization[/Bearer (.+)/, 1]
+        return token if token
+      end
+
+      request.headers['X-Token']
+    end
+  end
+end

--- a/lib/openid_token_proxy/client.rb
+++ b/lib/openid_token_proxy/client.rb
@@ -1,6 +1,6 @@
 module OpenIDTokenProxy
   class Client
-    attr_reader :config
+    attr_accessor :config
 
     def initialize(config = OpenIDTokenProxy.config)
       @config = config

--- a/spec/dummy/app/controllers/accounts_controller.rb
+++ b/spec/dummy/app/controllers/accounts_controller.rb
@@ -1,0 +1,9 @@
+class AccountsController < ApplicationController
+  include OpenIDTokenProxy::Authentication
+
+  require_valid_token
+
+  def show
+    render json: current_token, status: :ok
+  end
+end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  include OpenIDTokenProxy::Authentication
+
   def index
   end
 end

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -1,1 +1,23 @@
 Visit <a href="<%= OpenIDTokenProxy.client.authorization_uri %>"> authorization URI</a> and sign in.
+
+<% if raw_token %>
+  <hr />
+
+  <dl>
+    <dt>Token</dt>
+    <dd><%= current_token %></dd>
+  </dl>
+
+  <hr />
+
+  <%= link_to 'Use your token', account_path(token: current_token) %> for API authentication.
+
+  <hr />
+
+  <dd>
+    <% current_token.id_token.raw_attributes.each_pair do |key, value| %>
+      <dt><%= key.humanize %></dt>
+      <dd><%= value %></dd>
+    <% end %>
+  </dl>
+<% end %>

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
 
     dd {
       margin: 0 1em;
+      word-break: break-all;
     }
 
     hr {

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   root to: 'home#index'
+  resource :account
   mount OpenIDTokenProxy::Engine, at: '/auth'
 end

--- a/spec/lib/openid_token_proxy/authentication_spec.rb
+++ b/spec/lib/openid_token_proxy/authentication_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    include OpenIDTokenProxy::Authentication
+
+    require_valid_token
+
+    def index
+      raise OpenIDTokenProxy::Error if params[:error]
+      render nothing: true, status: :ok
+    end
+  end
+
+  context 'when token proxy errors are encountered' do
+    it 'results in 401 UNAUTHORIZED with authorization URI' do
+      get :index, error: true
+      expect(response).to have_http_status :unauthorized
+      expect(response.headers).to have_key 'X-Authorization-URI'
+    end
+  end
+
+  context 'when no token proxy errors are encountered' do
+    it 'executes actions normally' do
+      token = double(validate!: true)
+      expect(controller).to receive(:current_token).and_return token
+      get :index
+      expect(response).to have_http_status :ok
+    end
+  end
+
+  describe '#current_token' do
+    it 'returns current valid token' do
+      token = double
+      expect(OpenIDTokenProxy::Token).to receive(:decode!).and_return token
+      expect(controller.current_token).to eq token
+    end
+  end
+
+  describe '#raw_token' do
+    it 'may be provided as parameter' do
+      get :index, token: 'raw token'
+      expect(controller.raw_token).to eq 'raw token'
+    end
+
+    it 'may be provided through authorization header' do
+      request.headers['Authorization'] = 'Bearer raw token'
+      get :index
+      expect(controller.raw_token).to eq 'raw token'
+    end
+
+    it 'may be provided through X-Token header' do
+      request.headers['X-Token'] = 'raw token'
+      get :index
+      expect(controller.raw_token).to eq 'raw token'
+    end
+  end
+end


### PR DESCRIPTION
This extends the informational homepage from #20 by:

- Displaying identity information from the token on the homepage.
- Linking to `/account`, which is a sample API endpoint requiring token authentication.

Note that this includes #36 since it relies on it.

![screen shot 2015-04-25 at 22 28 47](https://cloud.githubusercontent.com/assets/378235/7334868/f98e91dc-eba0-11e4-9f36-c4403d4fde83.png)
