### PR TITLE
Handle authorization code failure

### DIFF
--- a/app/controllers/openid_token_proxy/callback_controller.rb
+++ b/app/controllers/openid_token_proxy/callback_controller.rb
@@ -9,11 +9,13 @@ module OpenIDTokenProxy
       begin
         token = OpenIDTokenProxy.client.token_via_auth_code!(code)
       rescue OpenIDTokenProxy::Client::AuthCodeError => error
-        # Rescued here and passed into the token acquirement hook below
+        render text: "Could not exchange authorization code: #{error.message}.",
+               status: :bad_request
+        return
       end
 
       config = OpenIDTokenProxy.config
-      uri = instance_exec token, error, &config.token_acquirement_hook
+      uri = instance_exec token, &config.token_acquirement_hook
       redirect_to uri || main_app.root_url unless performed?
     end
   end

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -16,41 +16,53 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
   end
 
   context 'when authorization code is given' do
-    before do
-      expect(client).to receive(:token_via_auth_code!).and_return token
-    end
-
-    context 'with no-op token acquirement hook' do
-      it 'redirects to root' do
-        OpenIDTokenProxy.configure_temporarily do |config|
-          config.token_acquirement_hook = proc { }
-          get :handle, code: auth_code
-          expect(response).to redirect_to controller.main_app.root_url
-        end
+    context 'when authorization code could not be exchanged' do
+      it 'results in 400 BAD REQUEST with error message' do
+        error = OpenIDTokenProxy::Client::AuthCodeError.new 'msg'
+        expect(client).to receive(:token_via_auth_code!).and_raise error
+        get :handle, code: auth_code
+        expect(response.body).to eq 'Could not exchange authorization code: msg.'
+        expect(response).to have_http_status :bad_request
       end
     end
 
-    context 'when returning URI from token acquirement hook' do
-      it 'redirects to returned URI' do
-        OpenIDTokenProxy.configure_temporarily do |config|
-          uri = '/#token'
-          config.token_acquirement_hook = proc { |token, error|
-            uri
-          }
-          get :handle, code: auth_code
-          expect(response).to redirect_to uri
+    context 'when authorization code could be exchanged' do
+      before do
+        expect(client).to receive(:token_via_auth_code!).and_return token
+      end
+
+      context 'with no-op token acquirement hook' do
+        it 'redirects to root' do
+          OpenIDTokenProxy.configure_temporarily do |config|
+            config.token_acquirement_hook = proc { }
+            get :handle, code: auth_code
+            expect(response).to redirect_to controller.main_app.root_url
+          end
         end
       end
-    end
 
-    context 'when performing an action within token acquirement hook' do
-      it 'takes no additional action' do
-        OpenIDTokenProxy.configure_temporarily do |config|
-          config.token_acquirement_hook = proc { |token, error|
-            render text: 'Custom action'
-          }
-          get :handle, code: auth_code
-          expect(response.body).to eq 'Custom action'
+      context 'when returning URI from token acquirement hook' do
+        it 'redirects to returned URI' do
+          OpenIDTokenProxy.configure_temporarily do |config|
+            uri = '/#token'
+            config.token_acquirement_hook = proc { |token, error|
+              uri
+            }
+            get :handle, code: auth_code
+            expect(response).to redirect_to uri
+          end
+        end
+      end
+
+      context 'when performing an action within token acquirement hook' do
+        it 'takes no additional action' do
+          OpenIDTokenProxy.configure_temporarily do |config|
+            config.token_acquirement_hook = proc { |token, error|
+              render text: 'Custom action'
+            }
+            get :handle, code: auth_code
+            expect(response.body).to eq 'Custom action'
+          end
         end
       end
     end


### PR DESCRIPTION
Let's have the proxy handle errors instead of leaving it up to an individual application to inspect the error state.