### PR TITLE
Add token refresh module

### DIFF
--- a/app/controllers/openid_token_proxy/callback_controller.rb
+++ b/app/controllers/openid_token_proxy/callback_controller.rb
@@ -7,7 +7,7 @@ module OpenIDTokenProxy
       end
 
       begin
-        token = OpenIDTokenProxy.client.token_via_auth_code!(code)
+        token = OpenIDTokenProxy.client.retrieve_token!(auth_code: code)
       rescue OpenIDTokenProxy::Client::AuthCodeError => error
         render text: "Could not exchange authorization code: #{error.message}.",
                status: :bad_request

--- a/lib/openid_token_proxy.rb
+++ b/lib/openid_token_proxy.rb
@@ -9,6 +9,7 @@ require 'openid_token_proxy/config'
 require 'openid_token_proxy/engine'
 require 'openid_token_proxy/token'
 require 'openid_token_proxy/token/authentication'
+require 'openid_token_proxy/token/refresh'
 require 'openid_token_proxy/version'
 
 module OpenIDTokenProxy

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -1,0 +1,30 @@
+require 'active_support/concern'
+
+module OpenIDTokenProxy
+  class Token
+    module Refresh
+      extend ActiveSupport::Concern
+
+      included do
+        include OpenIDTokenProxy::Token::Authentication
+
+        helper_method :raw_refresh_token
+
+        def require_valid_token
+          super
+        rescue OpenIDTokenProxy::Token::Expired
+          raise unless raw_refresh_token.present?
+          @current_token = OpenIDTokenProxy.client.retrieve_token!(
+            refresh_token: raw_refresh_token
+          )
+          response.headers['X-Token'] = current_token.access_token
+          response.headers['X-Refresh-Token'] = current_token.refresh_token
+        end
+      end
+
+      def raw_refresh_token
+        params[:refresh_token] || request.headers['X-Refresh-Token']
+      end
+    end
+  end
+end

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
     context 'when authorization code could not be exchanged' do
       it 'results in 400 BAD REQUEST with error message' do
         error = OpenIDTokenProxy::Client::AuthCodeError.new 'msg'
-        expect(client).to receive(:token_via_auth_code!).and_raise error
+        expect(client).to receive(:retrieve_token!).with(
+          auth_code: auth_code
+        ).and_raise error
         get :handle, code: auth_code
         expect(response.body).to eq 'Could not exchange authorization code: msg.'
         expect(response).to have_http_status :bad_request
@@ -28,7 +30,7 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
 
     context 'when authorization code could be exchanged' do
       before do
-        expect(client).to receive(:token_via_auth_code!).and_return token
+        expect(client).to receive(:retrieve_token!).and_return token
       end
 
       context 'with no-op token acquirement hook' do

--- a/spec/dummy/app/controllers/accounts_controller.rb
+++ b/spec/dummy/app/controllers/accounts_controller.rb
@@ -1,5 +1,6 @@
 class AccountsController < ApplicationController
   include OpenIDTokenProxy::Token::Authentication
+  include OpenIDTokenProxy::Token::Refresh
 
   require_valid_token
 

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 class HomeController < ApplicationController
   include OpenIDTokenProxy::Token::Authentication
+  include OpenIDTokenProxy::Token::Refresh
 
   def index
   end

--- a/spec/dummy/app/views/home/index.html.erb
+++ b/spec/dummy/app/views/home/index.html.erb
@@ -6,11 +6,13 @@ Visit <a href="<%= OpenIDTokenProxy.client.authorization_uri %>"> authorization 
   <dl>
     <dt>Token</dt>
     <dd><%= current_token %></dd>
+    <dt>Refresh token</dt>
+    <dd><%= raw_refresh_token || '-' %></dd>
   </dl>
 
   <hr />
 
-  <%= link_to 'Use your token', account_path(token: current_token) %> for API authentication.
+  <%= link_to 'Use your token', account_path(token: current_token, refresh_token: raw_refresh_token) %> for API authentication.
 
   <hr />
 

--- a/spec/dummy/config/initializers/openid.rb
+++ b/spec/dummy/config/initializers/openid.rb
@@ -1,5 +1,5 @@
 OpenIDTokenProxy.configure do |config|
-  config.token_acquirement_hook = proc { |token, error|
-    main_app.root_url + "?token=#{token}"
+  config.token_acquirement_hook = proc { |token|
+    main_app.root_url + "?token=#{token}&refresh_token=#{token.refresh_token}"
   }
 end

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
+  let(:authorization_uri) { 'https://id.hyper.no/authorize' }
+  let(:refresh_token) { 'refresh token' }
+  let(:token) {
+    OpenIDTokenProxy::Token.new('expired access token', nil, refresh_token)
+  }
+  let(:refreshed_token) {
+    OpenIDTokenProxy::Token.new('new access token', nil, 'new refresh token')
+  }
+
+  before do
+    expect(token).to receive(:validate!).and_raise OpenIDTokenProxy::Token::Expired
+    expect(OpenIDTokenProxy::Token).to receive(:decode!).and_return token
+  end
+
+  controller(ApplicationController) do
+    include OpenIDTokenProxy::Token::Refresh
+
+    require_valid_token
+
+    def index
+      render text: 'Refresh successful', status: :ok
+    end
+  end
+
+  context 'when token has expired' do
+    context 'when refresh token could not be exchanged' do
+      it 'results in 401 UNAUTHORIZED with authentication URI' do
+        error = OpenIDTokenProxy::Client::RefreshTokenError.new 'msg'
+        expect(OpenIDTokenProxy.client).to receive(:retrieve_token!).with(
+          refresh_token: refresh_token
+        ).and_raise error
+        OpenIDTokenProxy.configure_temporarily do |config|
+          config.authorization_uri = authorization_uri
+          get :index, refresh_token: refresh_token
+        end
+        expect(response).to have_http_status :unauthorized
+        expect(response.headers['X-Authentication-URL']).to eq authorization_uri
+        expect(response.headers).not_to include 'X-Token', 'X-Refresh-Token'
+      end
+    end
+
+    context 'when token was refreshed successfully' do
+      it 'executes actions normally returning new tokens as headers' do
+        expect(OpenIDTokenProxy.client).to receive(:retrieve_token!).with(
+          refresh_token: refresh_token
+        ).and_return refreshed_token
+        get :index, refresh_token: refresh_token
+        expect(response).to have_http_status :ok
+        expect(response.body).to eq 'Refresh successful'
+        expect(response.headers['X-Token']).to eq 'new access token'
+        expect(response.headers['X-Refresh-Token']).to eq 'new refresh token'
+      end
+    end
+  end
+
+  describe '#raw_refresh_token' do
+    it 'may be provided as parameter' do
+      get :index, refresh_token: refresh_token
+      expect(controller.raw_refresh_token).to eq 'refresh token'
+    end
+
+    it 'may be provided through X-Refresh-Token header' do
+      request.headers['X-Refresh-Token'] = refresh_token
+      get :index
+      expect(controller.raw_refresh_token).to eq 'refresh token'
+    end
+  end
+end

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
   before do
     expect(token).to receive(:validate!).and_raise OpenIDTokenProxy::Token::Expired
     expect(OpenIDTokenProxy::Token).to receive(:decode!).and_return token
+    allow(OpenIDTokenProxy.client).to receive(:retrieve_token!).with(
+      refresh_token: refresh_token
+    ).and_return refreshed_token
   end
 
   controller(ApplicationController) do
@@ -44,9 +47,6 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
 
     context 'when token was refreshed successfully' do
       it 'executes actions normally returning new tokens as headers' do
-        expect(OpenIDTokenProxy.client).to receive(:retrieve_token!).with(
-          refresh_token: refresh_token
-        ).and_return refreshed_token
         get :index, refresh_token: refresh_token
         expect(response).to have_http_status :ok
         expect(response.body).to eq 'Refresh successful'


### PR DESCRIPTION
This refresh module will allow a client to send in a refresh token using the `X-Refresh-Token` header with which the token proxy would be able to obtain a new fresh token (given back as `X-Token`) and refresh token (given back as `X-Refresh-Token`).

Note that this includes #45 as it relies on it.