### PR TITLE
Token expiry time

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Access tokens may be provided with one of the following:
 - `Authorization: Bearer <token>` header.
 - Query string parameter `token`.
 
+Token expiry time will be exposed through the `X-Token-Expiry-Time` header.
+
 
 #### Identity / claims
 

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -52,6 +52,10 @@ module OpenIDTokenProxy
       true
     end
 
+    def expiry_time
+      Time.at(id_token.exp.to_i).utc
+    end
+
     def expired?
       id_token.exp.to_i <= Time.now.to_i
     end

--- a/lib/openid_token_proxy/token/authentication.rb
+++ b/lib/openid_token_proxy/token/authentication.rb
@@ -14,6 +14,7 @@ module OpenIDTokenProxy
       module ClassMethods
         def require_valid_token(*args)
           before_action :require_valid_token, *args
+          after_action :expose_token_expiry_time
         end
       end
 
@@ -31,6 +32,10 @@ module OpenIDTokenProxy
         config = OpenIDTokenProxy.config
         current_token.validate! audience: config.resource,
                                 client_id: config.client_id
+      end
+
+      def expose_token_expiry_time
+        response.headers['X-Token-Expiry-Time'] = current_token.expiry_time.iso8601
       end
 
       def current_token

--- a/spec/lib/openid_token_proxy/token/authentication_spec.rb
+++ b/spec/lib/openid_token_proxy/token/authentication_spec.rb
@@ -3,7 +3,13 @@ require 'spec_helper'
 RSpec.describe OpenIDTokenProxy::Token::Authentication, type: :controller do
   let(:authorization_uri) { 'https://id.hyper.no/authorize' }
   let(:access_token) { 'access token' }
-  let(:token) { OpenIDTokenProxy::Token.new(access_token) }
+  let(:expiry_time) { 2.hours.from_now }
+  let(:id_token) {
+    double(
+      exp: expiry_time
+    )
+  }
+  let(:token) { OpenIDTokenProxy::Token.new(access_token, id_token) }
 
   before do
     allow(token).to receive(:validate!).and_return true
@@ -37,6 +43,11 @@ RSpec.describe OpenIDTokenProxy::Token::Authentication, type: :controller do
       get :index
       expect(response).to have_http_status :ok
       expect(response.body).to eq 'Authentication successful'
+    end
+
+    it 'exposes token expiry time through header' do
+      get :index
+      expect(response.headers['X-Token-Expiry-Time']).to eq expiry_time.iso8601
     end
   end
 

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -6,8 +6,18 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
   let(:token) {
     OpenIDTokenProxy::Token.new('expired access token', nil, refresh_token)
   }
+  let(:refreshed_expiry_time) { 2.hours.from_now }
+  let(:refreshed_id_token) {
+    double(
+      exp: refreshed_expiry_time
+    )
+  }
   let(:refreshed_token) {
-    OpenIDTokenProxy::Token.new('new access token', nil, 'new refresh token')
+    OpenIDTokenProxy::Token.new(
+      'new access token',
+      refreshed_id_token,
+      'new refresh token'
+    )
   }
 
   before do
@@ -52,6 +62,7 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
         expect(response.body).to eq 'Refresh successful'
         expect(response.headers['X-Token']).to eq 'new access token'
         expect(response.headers['X-Refresh-Token']).to eq 'new refresh token'
+        expect(response.headers['X-Token-Expiry-Time']).to eq refreshed_expiry_time.iso8601
       end
     end
   end

--- a/spec/lib/openid_token_proxy/token_spec.rb
+++ b/spec/lib/openid_token_proxy/token_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe OpenIDTokenProxy::Token do
   let(:audience) { 'audience' }
   let(:client_id) { 'client ID' }
   let(:issuer) { 'issuer' }
-  let(:expiry_date) { 2.hours.from_now }
+  let(:expiry_time) { 2.hours.from_now }
 
   let(:id_token) {
     double(
-      exp: expiry_date,
+      exp: expiry_time,
       aud: audience,
       iss: issuer,
       raw_attributes: {
@@ -33,7 +33,7 @@ RSpec.describe OpenIDTokenProxy::Token do
 
   describe '#validate!' do
     context 'when token has expired' do
-      let(:expiry_date) { 2.hours.ago }
+      let(:expiry_time) { 2.hours.ago }
 
       it 'raises' do
         expect do
@@ -78,9 +78,19 @@ RSpec.describe OpenIDTokenProxy::Token do
     end
   end
 
+  describe '#expiry_time' do
+    it 'returns expiry time' do
+      expect(subject.expiry_time.to_i).to eq expiry_time.to_i
+    end
+
+    it 'is in UTC' do
+      expect(subject.expiry_time.zone).to eq 'UTC'
+    end
+  end
+
   describe '#expired?' do
     context 'when token has expired' do
-      let(:expiry_date) { 2.hours.ago }
+      let(:expiry_time) { 2.hours.ago }
       it { should be_expired }
     end
 


### PR DESCRIPTION
Exposes token expiry time through `X-Token-Expiry-Time` header. Fixes #55.