### PR TITLE
Allow retrieving token via credentials

### DIFF
--- a/openid-token-proxy.gemspec
+++ b/openid-token-proxy.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'openid_connect', '~> 0.8.3'
+  spec.add_dependency 'rack-oauth2', '~> 1.2.0'
   spec.add_dependency 'rails', '~> 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.6'


### PR DESCRIPTION
Although not a preferred OAuth or OpenID flow, the resource owner credentials grant allows retrieving a token via credentials without user interaction (e.g. opening up a browser window with the identity provider's log in page).

As such it can be used to validate credentials with the identity provider:

```ruby
token = OpenIDTokenProxy.client.retrieve_token!(
  username: 'foo',
  password: 'bar'
)
token.validate!
```