### PR TITLE
Allow hooking into token refreshment

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ token was obtained:
 - `X-Token` header containing the new access token to be used in future requests.
 - `X-Refresh-Token` header containing the new refresh token.
 
-You may configure some code to be ran (scoped to a controller) when a token is
+You may configure some code to be run (scoped to a controller) when a token is
 successfully refreshed:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ token was obtained:
 - `X-Token` header containing the new access token to be used in future requests.
 - `X-Refresh-Token` header containing the new refresh token.
 
+You may configure some code to be ran (scoped to a controller) when a token is
+successfully refreshed:
+
+```ruby
+OpenIDTokenProxy.configure do |config|
+  config.token_refreshment_hook = proc { |token|
+    cookies[:token] = token.access_token
+  }
+end
+```
+
 
 ## Contributing
 

--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -11,6 +11,7 @@ module OpenIDTokenProxy
                   :userinfo_endpoint, :end_session_endpoint
 
     attr_accessor :token_acquirement_hook
+    attr_accessor :token_refreshment_hook
     attr_accessor :public_keys
 
     def initialize
@@ -31,6 +32,7 @@ module OpenIDTokenProxy
       @end_session_endpoint = ENV['OPENID_END_SESSION_ENDPOINT']
 
       @token_acquirement_hook = proc { }
+      @token_refreshment_hook = proc { }
 
       yield self if block_given?
     end

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -18,12 +18,10 @@ module OpenIDTokenProxy
           response.headers['X-Token'] = current_token.access_token
           response.headers['X-Refresh-Token'] = current_token.refresh_token
 
-          token = OpenIDTokenProxy::Token.new(
-            current_token.access_token, current_token.id_token,
-            current_token.refresh_token
+          instance_exec(
+            current_token,
+            &OpenIDTokenProxy.config.token_refreshment_hook
           )
-
-          instance_exec(token, &OpenIDTokenProxy.config.token_refreshment_hook)
         end
       end
 

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -18,10 +18,12 @@ module OpenIDTokenProxy
           response.headers['X-Token'] = current_token.access_token
           response.headers['X-Refresh-Token'] = current_token.refresh_token
 
-          instance_exec(
-            current_token.access_token,
-            &OpenIDTokenProxy.config.token_refreshment_hook
+          token = OpenIDTokenProxy::Token.new(
+            current_token.access_token, current_token.id_token,
+            current_token.refresh_token
           )
+
+          instance_exec(token, &OpenIDTokenProxy.config.token_refreshment_hook)
         end
       end
 

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -17,6 +17,11 @@ module OpenIDTokenProxy
           )
           response.headers['X-Token'] = current_token.access_token
           response.headers['X-Refresh-Token'] = current_token.refresh_token
+
+          instance_exec(
+            current_token.access_token,
+            &OpenIDTokenProxy.config.token_refreshment_hook
+          )
         end
       end
 

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
         it 'redirects to root' do
           OpenIDTokenProxy.configure_temporarily do |config|
             block = double('block')
-            config.token_acquirement_hook = proc { |token, error|
-              block.run(token, error)
+            config.token_acquirement_hook = proc { |token|
+              block.run(token)
             }
-            expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token), nil)
+            expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token))
             get :handle, code: auth_code
             expect(response).to redirect_to controller.main_app.root_url
           end

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -36,12 +36,10 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
       context 'with no-op token acquirement hook' do
         it 'redirects to root' do
           OpenIDTokenProxy.configure_temporarily do |config|
-            block = double('block')
-            config.token_acquirement_hook = proc { |token|
-              block.run(token)
-            }
-            expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token))
-            get :handle, code: auth_code
+            expect do |probe|
+              config.token_acquirement_hook = probe
+              get :handle, code: auth_code
+            end.to yield_with_args(instance_of(OpenIDTokenProxy::Token))
             expect(response).to redirect_to controller.main_app.root_url
           end
         end

--- a/spec/controllers/openid_token_proxy/callback_controller_spec.rb
+++ b/spec/controllers/openid_token_proxy/callback_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
   let(:access_token) { 'access token' }
   let(:auth_code) { 'authorization code' }
   let(:client) { OpenIDTokenProxy.client }
-  let(:token) { double(access_token: access_token) }
+  let(:token) { OpenIDTokenProxy::Token.new 'token' }
 
   context 'when authorization code is missing' do
     it 'results in 400 BAD REQUEST with error message' do
@@ -36,7 +36,11 @@ RSpec.describe OpenIDTokenProxy::CallbackController, type: :controller do
       context 'with no-op token acquirement hook' do
         it 'redirects to root' do
           OpenIDTokenProxy.configure_temporarily do |config|
-            config.token_acquirement_hook = proc { }
+            block = double('block')
+            config.token_acquirement_hook = proc { |token, error|
+              block.run(token, error)
+            }
+            expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token), nil)
             get :handle, code: auth_code
             expect(response).to redirect_to controller.main_app.root_url
           end

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
       it 'executes actions normally returning new tokens as headers' do
         OpenIDTokenProxy.configure_temporarily do |config|
           block = double('block')
-          config.token_refreshment_hook = proc { |token, error| block.run }
-          expect(block).to receive(:run)
+          config.token_refreshment_hook = proc { |token, error| block.run(token, error) }
+          expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token), nil)
           get :index, refresh_token: refresh_token
           expect(response).to have_http_status :ok
           expect(response.body).to eq 'Refresh successful'

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
     context 'when token was refreshed successfully' do
       it 'executes actions normally returning new tokens as headers' do
         OpenIDTokenProxy.configure_temporarily do |config|
-          block = double('block')
-          config.token_refreshment_hook = proc { |token| block.run(token) }
-          expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token))
-          get :index, refresh_token: refresh_token
+          expect do |probe|
+            config.token_refreshment_hook = probe
+            get :index, refresh_token: refresh_token
+          end.to yield_with_args(instance_of(OpenIDTokenProxy::Token))
           expect(response).to have_http_status :ok
           expect(response.body).to eq 'Refresh successful'
           expect(response.headers['X-Token']).to eq 'new access token'

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
     context 'when token was refreshed successfully' do
       it 'executes actions normally returning new tokens as headers' do
         OpenIDTokenProxy.configure_temporarily do |config|
-          uri = '/#token'
           block = double('block')
           config.token_refreshment_hook = proc { |token, error| block.run }
           expect(block).to receive(:run)

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
       it 'executes actions normally returning new tokens as headers' do
         OpenIDTokenProxy.configure_temporarily do |config|
           block = double('block')
-          config.token_refreshment_hook = proc { |token, error| block.run(token, error) }
-          expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token), nil)
+          config.token_refreshment_hook = proc { |token| block.run(token) }
+          expect(block).to receive(:run).with(instance_of(OpenIDTokenProxy::Token))
           get :index, refresh_token: refresh_token
           expect(response).to have_http_status :ok
           expect(response.body).to eq 'Refresh successful'


### PR DESCRIPTION
I needed this to update a cookie with the new access token instead of just passing it back with headers.