### PR TITLE
Allow passing tokens and refresh tokens as cookies

### DIFF
--- a/lib/openid_token_proxy/token/authentication.rb
+++ b/lib/openid_token_proxy/token/authentication.rb
@@ -50,7 +50,7 @@ module OpenIDTokenProxy
           return token if token
         end
 
-        request.headers['X-Token']
+        cookies[:token] || request.headers['X-Token']
       end
     end
   end

--- a/lib/openid_token_proxy/token/authentication.rb
+++ b/lib/openid_token_proxy/token/authentication.rb
@@ -50,7 +50,7 @@ module OpenIDTokenProxy
           return token if token
         end
 
-        cookies[:token] || request.headers['X-Token']
+        request.headers['X-Token'] || cookies[:token]
       end
     end
   end

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -22,8 +22,8 @@ module OpenIDTokenProxy
 
       def raw_refresh_token
         params[:refresh_token] ||
-        cookies[:refresh_token] ||
-        request.headers['X-Refresh-Token']
+        request.headers['X-Refresh-Token'] ||
+        cookies[:refresh_token]
       end
     end
   end

--- a/lib/openid_token_proxy/token/refresh.rb
+++ b/lib/openid_token_proxy/token/refresh.rb
@@ -21,7 +21,9 @@ module OpenIDTokenProxy
       end
 
       def raw_refresh_token
-        params[:refresh_token] || request.headers['X-Refresh-Token']
+        params[:refresh_token] ||
+        cookies[:refresh_token] ||
+        request.headers['X-Refresh-Token']
       end
     end
   end

--- a/spec/lib/openid_token_proxy/token/authentication_spec.rb
+++ b/spec/lib/openid_token_proxy/token/authentication_spec.rb
@@ -74,5 +74,11 @@ RSpec.describe OpenIDTokenProxy::Token::Authentication, type: :controller do
       get :index
       expect(controller.raw_token).to eq 'raw token'
     end
+
+    it 'may be provided as a cookie' do
+      cookies[:token] = 'raw token'
+      get :index
+      expect(controller.raw_token).to eq 'raw token'
+    end
   end
 end

--- a/spec/lib/openid_token_proxy/token/refresh_spec.rb
+++ b/spec/lib/openid_token_proxy/token/refresh_spec.rb
@@ -78,5 +78,11 @@ RSpec.describe OpenIDTokenProxy::Token::Refresh, type: :controller do
       get :index
       expect(controller.raw_refresh_token).to eq 'refresh token'
     end
+
+    it 'may be provided as a cookie' do
+      cookies[:refresh_token] = refresh_token
+      get :index
+      expect(controller.raw_refresh_token).to eq 'refresh token'
+    end
   end
 end


### PR DESCRIPTION
I guess this is sorta weird, but it's common to need it when you're mounting the proxy as an engine in something that isn't an API. That's our use case, anyway.