### PR TITLE
Feature multiple audiences

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ OpenIDTokenProxy.configure do |config|
 
   # By default, only tokens issued for the resource above are accepted
   # Alternatively, you can override the allowed audiences or allow multiple:
-  config.audiences = ['https://id.hyper.no', 'https://graph.windows.net']
+  config.allowed_audiences = [
+    'https://id.hyper.no',
+    'https://graph.windows.net'
+  ]
 
   # Indicates which domain users will presumably be signing in with
   config.domain_hint = 'example.com'
@@ -89,7 +92,7 @@ end
 
 Alternatively, these environment variables will be picked up automatically:
 
-- `OPENID_AUDIENCES` (comma-separated list, defaults to `OPENID_RESOURCE`)
+- `OPENID_ALLOWED_AUDIENCES` (comma-separated, defaults to `OPENID_RESOURCE`)
 - `OPENID_AUTHORIZATION_ENDPOINT`
 - `OPENID_AUTHORIZATION_URI`
 - `OPENID_CLIENT_ID`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ OpenIDTokenProxy.configure do |config|
   config.redirect_uri = 'https://example.com/auth/callback'
   config.resource = 'https://graph.windows.net'
 
+  # By default, only tokens issued for the resource above are accepted
+  # Alternatively, you can override the allowed audiences or allow multiple:
+  config.audiences = ['https://id.hyper.no', 'https://graph.windows.net']
+
   # Indicates which domain users will presumably be signing in with
   config.domain_hint = 'example.com'
 
@@ -85,6 +89,7 @@ end
 
 Alternatively, these environment variables will be picked up automatically:
 
+- `OPENID_AUDIENCES` (comma-separated list, defaults to `OPENID_RESOURCE`)
 - `OPENID_AUTHORIZATION_ENDPOINT`
 - `OPENID_AUTHORIZATION_URI`
 - `OPENID_CLIENT_ID`

--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -5,7 +5,7 @@ module OpenIDTokenProxy
     attr_accessor :client_id, :client_secret, :issuer
     attr_accessor :domain_hint, :prompt, :redirect_uri, :resource
 
-    attr_writer :audiences
+    attr_writer :allowed_audiences
 
     attr_accessor :authorization_uri
 
@@ -26,8 +26,8 @@ module OpenIDTokenProxy
       @redirect_uri = ENV['OPENID_REDIRECT_URI']
       @resource = ENV['OPENID_RESOURCE']
 
-      @audiences = if ENV['OPENID_AUDIENCES']
-        ENV['OPENID_AUDIENCES'].split(',')
+      @allowed_audiences = if ENV['OPENID_ALLOWED_AUDIENCES']
+        ENV['OPENID_ALLOWED_AUDIENCES'].split(',')
       end
 
       @authorization_uri = ENV['OPENID_AUTHORIZATION_URI']
@@ -70,8 +70,8 @@ module OpenIDTokenProxy
       @public_keys ||= provider_config.public_keys
     end
 
-    def audiences
-      @audiences || Array(@resource)
+    def allowed_audiences
+      @allowed_audiences || Array(@resource)
     end
   end
 end

--- a/lib/openid_token_proxy/config.rb
+++ b/lib/openid_token_proxy/config.rb
@@ -5,6 +5,8 @@ module OpenIDTokenProxy
     attr_accessor :client_id, :client_secret, :issuer
     attr_accessor :domain_hint, :prompt, :redirect_uri, :resource
 
+    attr_writer :audiences
+
     attr_accessor :authorization_uri
 
     attr_accessor :authorization_endpoint, :token_endpoint,
@@ -23,6 +25,10 @@ module OpenIDTokenProxy
       @prompt = ENV['OPENID_PROMPT']
       @redirect_uri = ENV['OPENID_REDIRECT_URI']
       @resource = ENV['OPENID_RESOURCE']
+
+      @audiences = if ENV['OPENID_AUDIENCES']
+        ENV['OPENID_AUDIENCES'].split(',')
+      end
 
       @authorization_uri = ENV['OPENID_AUTHORIZATION_URI']
 
@@ -62,6 +68,10 @@ module OpenIDTokenProxy
 
     def public_keys
       @public_keys ||= provider_config.public_keys
+    end
+
+    def audiences
+      @audiences || Array(@resource)
     end
   end
 end

--- a/lib/openid_token_proxy/token.rb
+++ b/lib/openid_token_proxy/token.rb
@@ -27,20 +27,25 @@ module OpenIDTokenProxy
       id_token.raw_attributes[key]
     end
 
-    # Validates this token's expiration state, application, audience and issuer
+    # Validates this token's expiration state, application, audiences and issuer
     def validate!(assertions = {})
       raise Expired if expired?
 
       # TODO: Nonce validation
 
-      if assertions[:audience]
-        audiences = Array(id_token.aud)
-        raise InvalidAudience unless audiences.include? assertions[:audience]
+      audiences = assertions[:audiences] || Array(assertions[:audience])
+      if audiences.any?
+        audience = id_token.aud
+        unless audiences.include? audience
+          raise InvalidAudience.new(audience)
+        end
       end
 
       if assertions[:issuer]
         issuer = id_token.iss
-        raise InvalidIssuer unless issuer == assertions[:issuer]
+        unless issuer == assertions[:issuer]
+          raise InvalidIssuer.new(issuer)
+        end
       end
 
       true

--- a/lib/openid_token_proxy/token/authentication.rb
+++ b/lib/openid_token_proxy/token/authentication.rb
@@ -28,7 +28,7 @@ module OpenIDTokenProxy
 
       def require_valid_token
         config = OpenIDTokenProxy.config
-        current_token.validate! audience: config.resource
+        current_token.validate! audiences: config.audiences
       end
 
       def expose_token_expiry_time

--- a/lib/openid_token_proxy/token/authentication.rb
+++ b/lib/openid_token_proxy/token/authentication.rb
@@ -28,7 +28,7 @@ module OpenIDTokenProxy
 
       def require_valid_token
         config = OpenIDTokenProxy.config
-        current_token.validate! audiences: config.audiences
+        current_token.validate! audiences: config.allowed_audiences
       end
 
       def expose_token_expiry_time

--- a/lib/openid_token_proxy/token/invalid_audience.rb
+++ b/lib/openid_token_proxy/token/invalid_audience.rb
@@ -3,8 +3,8 @@ module OpenIDTokenProxy
 
     # Raised when a token's audience did not match
     class InvalidAudience < Error
-      def initialize
-        super 'Token was issued for an unexpected audience/resource.'
+      def initialize(audience)
+        super "Token was issued for an unexpected audience: #{audience}."
       end
     end
 

--- a/lib/openid_token_proxy/token/invalid_issuer.rb
+++ b/lib/openid_token_proxy/token/invalid_issuer.rb
@@ -3,8 +3,8 @@ module OpenIDTokenProxy
 
     # Raised when a token's issuer did not match
     class InvalidIssuer < Error
-      def initialize
-        super 'Token was issued by an unexpected issuer.'
+      def initialize(issuer)
+        super "Token was issued by an unexpected issuer: #{issuer}."
       end
     end
 

--- a/spec/lib/openid_token_proxy/config_spec.rb
+++ b/spec/lib/openid_token_proxy/config_spec.rb
@@ -109,6 +109,30 @@ RSpec.describe OpenIDTokenProxy::Config do
     end
   end
 
+  describe '#audiences' do
+    context 'obtaining its default from environment' do
+      it 'supports a single audience' do
+        stub_env('OPENID_AUDIENCES', 'foo')
+        expect(subject.audiences).to eq ['foo']
+      end
+
+      it 'supports multiple audiences' do
+        stub_env('OPENID_AUDIENCES', 'foo,bar')
+        expect(subject.audiences).to eq ['foo', 'bar']
+      end
+    end
+
+    it 'may be set explicitly' do
+      subject.audiences = ['overridden']
+      expect(subject.audiences).to eq ['overridden']
+    end
+
+    it 'may be obtained implicitly from resource' do
+      subject.resource = 'resource'
+      expect(subject.audiences).to eq ['resource']
+    end
+  end
+
   describe '#authorization_uri' do
     it 'obtains its default from environment' do
       stub_env('OPENID_AUTHORIZATION_URI', 'from env')

--- a/spec/lib/openid_token_proxy/config_spec.rb
+++ b/spec/lib/openid_token_proxy/config_spec.rb
@@ -109,27 +109,27 @@ RSpec.describe OpenIDTokenProxy::Config do
     end
   end
 
-  describe '#audiences' do
+  describe '#allowed_audiences' do
     context 'obtaining its default from environment' do
       it 'supports a single audience' do
-        stub_env('OPENID_AUDIENCES', 'foo')
-        expect(subject.audiences).to eq ['foo']
+        stub_env('OPENID_ALLOWED_AUDIENCES', 'foo')
+        expect(subject.allowed_audiences).to eq ['foo']
       end
 
       it 'supports multiple audiences' do
-        stub_env('OPENID_AUDIENCES', 'foo,bar')
-        expect(subject.audiences).to eq ['foo', 'bar']
+        stub_env('OPENID_ALLOWED_AUDIENCES', 'foo,bar')
+        expect(subject.allowed_audiences).to eq ['foo', 'bar']
       end
     end
 
     it 'may be set explicitly' do
-      subject.audiences = ['overridden']
-      expect(subject.audiences).to eq ['overridden']
+      subject.allowed_audiences = ['overridden']
+      expect(subject.allowed_audiences).to eq ['overridden']
     end
 
     it 'may be obtained implicitly from resource' do
       subject.resource = 'resource'
-      expect(subject.audiences).to eq ['resource']
+      expect(subject.allowed_audiences).to eq ['resource']
     end
   end
 

--- a/spec/lib/openid_token_proxy/token_spec.rb
+++ b/spec/lib/openid_token_proxy/token_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe OpenIDTokenProxy::Token do
       end
     end
 
+    context 'when audience is not white-listed' do
+      it 'raises' do
+        expect do
+          subject.validate! audiences: ['expected', 'audiences']
+        end.to raise_error OpenIDTokenProxy::Token::InvalidAudience
+      end
+    end
+
     context 'when issuer differs' do
       it 'raises' do
         expect do
@@ -59,12 +67,24 @@ RSpec.describe OpenIDTokenProxy::Token do
     end
 
     context 'when all is well' do
-      it 'returns true' do
-        assertions = {
-          audience: audience,
-          issuer: issuer
-        }
-        expect(subject.validate! assertions).to be_truthy
+      context 'with a single audience' do
+        it 'returns true' do
+          assertions = {
+            audience: audience,
+            issuer: issuer
+          }
+          expect(subject.validate! assertions).to be_truthy
+        end
+      end
+
+      context 'with multiple audiences in white list' do
+        it 'returns true' do
+          assertions = {
+            audiences: [audience, 'other allowed audience'],
+            issuer: issuer
+          }
+          expect(subject.validate! assertions).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
This allows the `Token::Authentication` module to accept multiple audiences, useful when an API has to use a token on behalf of a user for a different resource.
